### PR TITLE
Improve non-interactive PE analysis implementation and updated and tested some examples

### DIFF
--- a/R/PcAnalysisApi.R
+++ b/R/PcAnalysisApi.R
@@ -216,7 +216,8 @@ SetupAnalysis_PC <- function(
 #' @param state A "PCAnalysisState" object.
 #' @param p_raw Named numeric vector of raw p-values for the current look, for the
 #'   currently active hypotheses (state$mcpObj$IndexSet).
-#' @param Correlation Optional D x D correlation matrix. This input is mandatory
+#' @param Correlation Optional D_active x D_active correlation matrix for the
+#'   currently active hypotheses (\code{length(state$mcpObj$IndexSet)}). Mandatory
 #'   at look 1 when \code{test.type} is \code{"Dunnett"} or \code{"Partly-Parametric"}.
 #'   For subsequent looks, if supplied for those test types it updates the
 #'   correlation used in analysis; if \code{NULL}, the most recently stored
@@ -325,6 +326,16 @@ AnalyzeLook_PC <- function(
   mcpObj$CurrentLook <- next_look
 
   p_raw <- validate_p_raw(p_raw, mcpObj$IndexSet)
+
+  if (!is.null(Correlation) && is.matrix(Correlation)) {
+    n_active <- length(mcpObj$IndexSet)
+    if (!all(dim(Correlation) == c(n_active, n_active))) {
+      stop(
+        "Correlation must be a ", n_active, " x ", n_active,
+        " matrix matching the currently active hypotheses."
+      )
+    }
+  }
 
   if (!is.null(Correlation) &&
       mcpObj$test.type %in% c("Dunnett", "Partly-Parametric")) {

--- a/R/PeAnalysisApi.R
+++ b/R/PeAnalysisApi.R
@@ -294,10 +294,12 @@ SetupAnalysis_PE_PC <- function(
 #'
 #' @param state A "PCAnalysisState" object created by [SetupAnalysis_PE_PC()].
 #' @param p_raw Named numeric vector of raw p-values for active hypotheses.
-#' @param fullpop_sample_sizes Numeric vector of full-population sample sizes
-#' ordered as control first, then treatment arms.
-#' @param subpop_sample_sizes Numeric vector of subgroup sample sizes ordered as
-#' control first, then treatment arms.
+#' @param fullpop_sample_sizes Numeric vector of cumulative full-population sample
+#' sizes ordered as control first, then treatment arms. Must be non-decreasing
+#' across looks and the same length at every look.
+#' @param subpop_sample_sizes Numeric vector of cumulative subgroup sample sizes
+#' ordered as control first, then treatment arms. Must be non-decreasing across
+#' looks and the same length at every look.
 #' @param look Optional positive integer naming the current look number.
 #' @param selection Optional character vector of hypotheses to retain for this
 #' look (only meaningful when look > 1).
@@ -319,63 +321,54 @@ AnalyzeLook_PE_PC <- function(
     new_G = NULL,
     plotGraphs = TRUE )
 {
-  if( !is.null( new_weights ) )
+  if( state$completed_looks > 0L )
   {
-    n_hypotheses <- length( new_weights )
-  } else if( state$completed_looks == 0L )
-  {
-    n_hypotheses <- length( state$mcpObj$IntialWeights )
-  } else
-  {
-    n_hypotheses <- length( state$mcpObj$IndexSet )
+    vPrevFull <- state$pe_sample_history[[ state$completed_looks ]]$fullpop
+    vPrevSub  <- state$pe_sample_history[[ state$completed_looks ]]$subpop
+
+    if( length( fullpop_sample_sizes ) != length( vPrevFull ) ||
+        length( subpop_sample_sizes ) != length( vPrevSub ) )
+    {
+      stop(
+        "fullpop_sample_sizes and subpop_sample_sizes must have the same length as at look 1."
+      )
+    }
+
+    if( any( fullpop_sample_sizes < vPrevFull ) || any( subpop_sample_sizes < vPrevSub ) )
+    {
+      stop( "Cumulative sample sizes must be non-decreasing across looks." )
+    }
   }
 
-  hypothesis_names <- names( new_weights )
-  if( is.null( hypothesis_names ) || !all( nzchar( hypothesis_names, keepNA = TRUE ) ) )
-  {
-    hypothesis_names <- names( p_raw )
-  }
-
-  if( is.null( hypothesis_names ) || !all( nzchar( hypothesis_names, keepNA = TRUE ) ) )
-  {
-    hypothesis_names <- state$mcpObj$IndexSet
-  }
-
-  if( length( hypothesis_names ) != n_hypotheses && length( state$mcpObj$IndexSet ) == n_hypotheses )
-  {
-    hypothesis_names <- state$mcpObj$IndexSet
-  }
-
-  if( length( hypothesis_names ) != n_hypotheses && length( names( p_raw ) ) == n_hypotheses )
-  {
-    hypothesis_names <- names( p_raw )
-  }
-
-  if( length( hypothesis_names ) != n_hypotheses )
-  {
-    hypothesis_names <- paste0( "H", seq_len( n_hypotheses ) )
-  }
-
-  dCorrelation <- BuildPECorrelationMatrix(
+  n_initial <- length( state$mcpObj$IntialHypothesis )
+  dFullCorrelation <- BuildPECorrelationMatrix(
     fullpop_sample_sizes = fullpop_sample_sizes,
-    subpop_sample_sizes = subpop_sample_sizes,
-    n_hypotheses = n_hypotheses,
-    hypothesis_names = hypothesis_names
+    subpop_sample_sizes  = subpop_sample_sizes,
+    n_hypotheses         = n_initial,
+    hypothesis_names     = state$mcpObj$IntialHypothesis
   )
 
-  return(
-    do.call(
-      AnalyzeLook_PC,
-      list(
-        state = state,
-        p_raw = p_raw,
-        Correlation = dCorrelation,
-        look = look,
-        selection = selection,
-        new_weights = new_weights,
-        new_G = new_G,
-        plotGraphs = plotGraphs
-      )
+  vActiveNames <- state$mcpObj$IndexSet
+  dCorrelation <- dFullCorrelation[ vActiveNames, vActiveNames, drop = FALSE ]
+
+  state <- do.call(
+    AnalyzeLook_PC,
+    list(
+      state = state,
+      p_raw = p_raw,
+      Correlation = dCorrelation,
+      look = look,
+      selection = selection,
+      new_weights = new_weights,
+      new_G = new_G,
+      plotGraphs = plotGraphs
     )
   )
+
+  state$pe_sample_history[[ state$completed_looks ]] <- list(
+    fullpop = fullpop_sample_sizes,
+    subpop  = subpop_sample_sizes
+  )
+
+  return( state )
 }

--- a/internalData/PopEnrich_Analysis_Ex.R
+++ b/internalData/PopEnrich_Analysis_Ex.R
@@ -1,18 +1,62 @@
 # Examples for analysis in the population enrichment case
 library(AdaptGMCP)
 
-# # EXAMPLE 5 #############################################
-# # Setting input parameters for the function
+# # EXAMPLE 1 #############################################
+# # Simplest population enrichment problem with 1 treatment and 1 control arm
+# # 1 endpoint, and 1 full population and 1 subpopulation
+# # Fixed sample design
+# # Total sample size = 200, balanced allocation between treatment and control arms
+# # Subpopulation is 50% of full population
 
+# # Setting input parameters for the function
 # # Weights
 # wi <- rep(0.5, 2) # Initial weights for the 2 hypotheses
-# stopifnot(length(wi) == 2)
 
 # # Transition matrix
 # g <- matrix(c(0, 1, 1, 0), byrow = T, nrow = 2)
 
 # # Test type
-# test <- "Dunnett" # "Bonf" # "Partly-Parametric" #
+# test <- "Dunnett"
+
+# # Type I error
+# alp <- 0.025
+
+# # Info fraction
+# t <- 1
+
+# # Setting up the design first
+# design <- SetupAnalysis_PE_PC(
+#   WI = wi,
+#   G = g,
+#   test.type = test,
+#   alpha = alp,
+#   info_frac = t)
+
+# print(design)
+
+# # Performing analysis
+# look1_out <- AnalyzeLook_PE_PC(
+#   design,
+#   p_raw = c(H1 = 0.1, H2 = 0.0025),
+#   fullpop_sample_sizes = c(100, 100), # Sample sizes are specified first for control and then for treatment arm
+#   subpop_sample_sizes = c(50, 50)) # Sample sizes are specified first for control and then for treatment arm
+
+# print(look1_out$mcpObj$Correlation)
+# print(look1_out)
+# #########################################################
+
+# # EXAMPLE 2 #############################################
+# # Sample as Example 1, but with 1 interim look
+
+# # Setting input parameters for the function
+# # Weights
+# wi <- rep(0.5, 2) # Initial weights for the 2 hypotheses
+
+# # Transition matrix
+# g <- matrix(c(0, 1, 1, 0), byrow = T, nrow = 2)
+
+# # Test type
+# test <- "Dunnett"
 
 # # Type I error
 # alp <- 0.025
@@ -23,37 +67,144 @@ library(AdaptGMCP)
 # # Design type
 # des <- "asOF"
 
-# # Correlation matrix between test stats
-# corr <- matrix(c(1, 0.5, 0.5, 1), byrow = T, nrow = 2)
-
-# x <- AdaptGMCP:::conn.comp(corr)
-# print(x)
-
-# y <- AdaptGMCP:::clique.partition(corr)
-# print(y)
-
-# # Calling the analysis function for p-value combination method
-# design <- SetupAnalysis_PC(
+# # Setting up the design first
+# design <- SetupAnalysis_PE_PC(
 #   WI = wi,
 #   G = g,
 #   test.type = test,
 #   alpha = alp,
 #   info_frac = t,
-#   typeOfDesign = des,
-#   Correlation = corr,
-#   plotGraphs = TRUE,
-#   MultipleWinners = TRUE
-# )
+#   typeOfDesign = des
+#   )
 
-# # Look 1
-# look1_out <- AnalyzeLook_PC(
+# print(design)
+
+# # Performing analysis for look 1
+# look1_out <- AnalyzeLook_PE_PC(
 #   design,
-#   p_raw = c(H1 = 0.025, H2 = 0.025), plotGraphs = TRUE
-# )
+#   p_raw = c(H1 = 0.1, H2 = 0.075),
+#   fullpop_sample_sizes = c(48, 53), # Sample sizes are specified first for control and then for treatment arm
+#   subpop_sample_sizes = c(26, 24)) # Sample sizes are specified first for control and then for treatment arm
 
-# look1_out
+# print(look1_out$mcpObj$Correlation)
+# print(look1_out)
+
+# # Performing analysis for look 2
+# look2_out <- AnalyzeLook_PE_PC(
+#   look1_out,
+#   p_raw = c(H1 = 0.08, H2 = 0.003),
+#   fullpop_sample_sizes = c(100, 100), # Sample sizes are specified first for control and then for treatment arm
+#   subpop_sample_sizes = c(53, 49)) # Sample sizes are specified first for control and then for treatment arm
+
+# print(look2_out$mcpObj$Correlation)
+# print(look2_out)
 # #########################################################
 
+# EXAMPLE 3 #############################################
+# Severe oral mucocites example
+# H1: high dose, full population
+# H2: low dose, full population
+# H3: high dose, HPV+ subgroup
+# H4: low dose, HPV+ subgroup
+# Single endpoint
+# Total sample size = 300, balanced allocation to all arms
+# Subpopulation is 50% of full population
+# One interim look at 50% information fraction
+# Ref: CIT\MAMS\adaptgmcp-resources\GMCP papers, etc\Cyrus' Talk - AdaptGMCP - Sep 2025.pdf
+
+# Setting input parameters for the function
+# Weights
+wi <- rep(0.25, 4) # Initial weights for the 4 hypotheses
+
+# Transition matrix
+g <- matrix(c(0, 0, 1, 0,
+              0, 0, 0, 1,
+              0, 1, 0, 0,
+              1, 0, 0, 0), byrow = T, nrow = 4)
+
+# Test type
+test <- "Dunnett"
+
+# Type I error
+alp <- 0.025
+
+# Info fraction
+t <- c(0.5, 1)
+
+# Design type
+des <- "asOF"
+
+# # Setting up the design first
+# design <- SetupAnalysis_PE_PC(
+#   WI = wi,
+#   G = g,
+#   test.type = test,
+#   alpha = alp,
+#   info_frac = t,
+#   typeOfDesign = des)
+
+# print(design)
+
+# # Performing analysis at look 1
+# look1_out <- AnalyzeLook_PE_PC(
+#   design,
+#   p_raw = c(H1 = 0.00045, H2 = 0.0952, H3 = 0.0225, H4 = 0.1104),
+#   fullpop_sample_sizes = c(50, 50, 50), # Sample sizes: first for control and then for treatment arms
+#   subpop_sample_sizes = c(25, 25, 25)) # Sample sizes: first for control and then for treatment arms
+
+# print(look1_out$mcpObj$Correlation)
+# print(look1_out)
+
+# # No hypotheses are rejected at look 1
+
+# # Performing analysis at look 2
+# look2_out <- AnalyzeLook_PE_PC(
+#   look1_out,
+#   p_raw = c(H1 = 0.00045, H2 = 0.1121, H3 = 0.0112, H4 = 0.1153),
+#   fullpop_sample_sizes = c(100, 100, 100), # Sample sizes: first for control and then for treatment arms
+#   subpop_sample_sizes = c(50, 50, 50)) # Sample sizes: first for control and then for treatment arms
+
+# print(look2_out$mcpObj$Correlation)
+# print(look2_out)
+
+# >>> Trying with higher look 1 info fract
+
+# Setting up the design first
+design <- SetupAnalysis_PE_PC(
+  WI = wi,
+  G = g,
+  test.type = test,
+  alpha = alp,
+  info_frac = c(0.7, 1),
+  typeOfDesign = des)
+
+print(design)
+
+# Performing analysis at look 1
+look1_out <- AnalyzeLook_PE_PC(
+  design,
+  p_raw = c(H1 = 0.00045, H2 = 0.0952, H3 = 0.0225, H4 = 0.1104),
+  fullpop_sample_sizes = c(50, 50, 50), # Sample sizes: first for control and then for treatment arms
+  subpop_sample_sizes = c(25, 25, 25)) # Sample sizes: first for control and then for treatment arms
+
+print(look1_out$mcpObj$Correlation)
+print(look1_out)
+
+# H1 is rejected at look 1.
+
+# Performing analysis at look 2
+look2_out <- AnalyzeLook_PE_PC(
+  look1_out,
+  p_raw = c(H2 = 0.1121, H3 = 0.0112, H4 = 0.1153),
+  fullpop_sample_sizes = c(100, 100, 100), # Sample sizes: first for control and then for treatment arms
+  subpop_sample_sizes = c(50, 50, 50)) # Sample sizes: first for control and then for treatment arms
+
+print(look2_out$mcpObj$Correlation)
+print(look2_out)
+
+#########################################################
+
+#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # EXAMPLE 4 #############################################
 # Problem: Full population and a subpopulation (50% of full population)
 # High dose and low dose of the drug being tested

--- a/tests/testthat/test-PcAnalysisApi.R
+++ b/tests/testthat/test-PcAnalysisApi.R
@@ -250,8 +250,8 @@ testthat::test_that("Test 3: PC analysis API scaffolds (full transition at look 
     1, 0, 0
   ), byrow = TRUE, nrow = 3)
 
-  # 3) correlation update (example: tweak H1-H2 and H1-H3)
-  Correlation <- corr
+  # 3) correlation update for the active hypotheses H1, H2, H3 only
+  Correlation <- corr[1:3, 1:3]
   Correlation[1, 2] <- Correlation[2, 1] <- 0.3
   Correlation[1, 3] <- Correlation[3, 1] <- 0.4
 
@@ -2200,7 +2200,7 @@ testthat::test_that("AnalyzeLook_PC: correlation update validity at look > 1", {
       Correlation = matrix(c(1, 0.5, 0.5, 1), nrow = 2),
       plotGraphs = FALSE
     ),
-    regexp = "Correlation must have dimensions"
+    regexp = "Correlation must be a"
   )
 
   # Non-symmetric Correlation must error


### PR DESCRIPTION
- Updated AnalyzeLook_PC() to make Correlation a D_active x D_active matrix so that it matches with how adaptGMCP_PC() accepts correlation input.
- Updated tests in test-PcAnalysisApi.R for this change.
- Updated AnalyzeLook_PE_PC() so that it accepts look wise cumulative sample sizes as inputs and validates for the same. Also, it now builds the full correlation matrix at every look regardless of how many hypotheses are active and then extracts the correlation submatrix for the active hypotheses.
- Updated PopEnrich_Analysis_Ex.R upto and including Example 3. Other examples not yet reviewed and updated for PE changes.